### PR TITLE
[BUG FIX] Update to default botocore impacting streaming to ElasticSearch

### DIFF
--- a/Visualisation/lambdas/lambdaDeploy.yaml
+++ b/Visualisation/lambdas/lambdaDeploy.yaml
@@ -72,6 +72,8 @@ Resources:
       MemorySize: 128
       Timeout: 10
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
+      Layers:
+        - !FindInMap [CustomLayersMap, !Ref "AWS::Region", PySDK]
       Environment:
         Variables:
           ELASTICSEARCH_ENDPOINT: 
@@ -84,3 +86,50 @@ Parameters:
     MinLength: 3
     MaxLength: 19
     AllowedPattern: "[a-z][a-z0-9-]+"
+
+Mappings:
+  CustomLayersMap: ## Missing Bahrain region me-south-1
+    ap-northeast-1:
+      "PySDK": "arn:aws:lambda:ap-northeast-1:249908578461:layer:AWSLambda-Python-AWS-SDK:1"
+    us-east-1:
+      "PySDK": "arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-southeast-1:
+      "PySDK": "arn:aws:lambda:ap-southeast-1:468957933125:layer:AWSLambda-Python-AWS-SDK:1"
+    eu-west-1:
+      "PySDK": "arn:aws:lambda:eu-west-1:399891621064:layer:AWSLambda-Python-AWS-SDK:1"
+    us-west-1:
+      "PySDK": "arn:aws:lambda:us-west-1:325793726646:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-east-1:
+      "PySDK": "arn:aws:lambda:ap-east-1:118857876118:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-northeast-2:
+      "PySDK": "arn:aws:lambda:ap-northeast-2:296580773974:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-northeast-3:
+      "PySDK": "arn:aws:lambda:ap-northeast-3:961244031340:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-south-1:
+      "PySDK": "arn:aws:lambda:ap-south-1:631267018583:layer:AWSLambda-Python-AWS-SDK:1"
+    ap-southeast-2:
+      "PySDK": "arn:aws:lambda:ap-southeast-2:817496625479:layer:AWSLambda-Python-AWS-SDK:1"
+    ca-central-1:
+      "PySDK": "arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:1"
+    eu-central-1:
+      "PySDK": "arn:aws:lambda:eu-central-1:292169987271:layer:AWSLambda-Python-AWS-SDK:1"
+    eu-north-1:
+      "PySDK": "arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1"
+    eu-west-2:
+      "PySDK": "arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1"
+    eu-west-3:
+      "PySDK": "arn:aws:lambda:eu-west-3:959311844005:layer:AWSLambda-Python-AWS-SDK:1"
+    sa-east-1:
+      "PySDK": "arn:aws:lambda:sa-east-1:640010853179:layer:AWSLambda-Python-AWS-SDK:1"
+    us-east-2:
+      "PySDK": "arn:aws:lambda:us-east-2:259788987135:layer:AWSLambda-Python-AWS-SDK:1"
+    us-west-2:
+      "PySDK": "arn:aws:lambda:us-west-2:420165488524:layer:AWSLambda-Python-AWS-SDK:1"
+    cn-north-1:
+      "PySDK": "arn:aws-cn:lambda:cn-north-1:683298794825:layer:AWSLambda-Python-AWS-SDK:1"
+    cn-northwest-1:
+      "PySDK": "arn:aws-cn:lambda:cn-northwest-1:382066503313:layer:AWSLambda-Python-AWS-SDK:1"
+    us-gov-west-1:
+      "PySDK": "arn:aws-us-gov:lambda:us-gov-west-1:556739011827:layer:AWSLambda-Python-AWS-SDK:1"
+    us-gov-east-1:
+      "PySDK": "arn:aws-us-gov:lambda:us-gov-east-1:138526772879:layer:AWSLambda-Python-AWS-SDK:1"


### PR DESCRIPTION
### Whats the issue?
An update to the botocore version inside Lambda prevents the ElasticSearch streaming function from working. The `SendDataCatalogUpdateToElasticSearch` lambda throws following errors in the cloudwatch logs:

> cannot import name 'BotocoreHTTPSession'

### How it impacts the data lake?
The data lake is **unable** to stream the status of files/event processing to elasticsearch. This is an important feature of accelerated data lake as it provides detailed insights into the success or failure of the data processed by the pipeline. 

### What are the changes?
The lambda team has published python sdk layers which can be configured for the impacted functions to resolve the issue. Following are the lambda layers available per region:

````
ap-northeast-1: arn:aws:lambda:ap-northeast-1:249908578461:layer:AWSLambda-Python-AWS-SDK:1
us-east-1: arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1
ap-southeast-1: arn:aws:lambda:ap-southeast-1:468957933125:layer:AWSLambda-Python-AWS-SDK:1
eu-west-1: arn:aws:lambda:eu-west-1:399891621064:layer:AWSLambda-Python-AWS-SDK:1
us-west-1: arn:aws:lambda:us-west-1:325793726646:layer:AWSLambda-Python-AWS-SDK:1
ap-east-1: arn:aws:lambda:ap-east-1:118857876118:layer:AWSLambda-Python-AWS-SDK:1
ap-northeast-2: arn:aws:lambda:ap-northeast-2:296580773974:layer:AWSLambda-Python-AWS-SDK:1
ap-northeast-3: arn:aws:lambda:ap-northeast-3:961244031340:layer:AWSLambda-Python-AWS-SDK:1
ap-south-1:631267018583: arn:aws:lambda:ap-south-1:631267018583:layer:AWSLambda-Python-AWS-SDK:1
ap-southeast-2: arn:aws:lambda:ap-southeast-2:817496625479:layer:AWSLambda-Python-AWS-SDK:1
ca-central-1: arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:1
eu-central-1: arn:aws:lambda:eu-central-1:292169987271:layer:AWSLambda-Python-AWS-SDK:1
eu-north-1: arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1
eu-west-2: arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1
eu-west-3: arn:aws:lambda:eu-west-3:959311844005:layer:AWSLambda-Python-AWS-SDK:1
sa-east-1: arn:aws:lambda:sa-east-1:640010853179:layer:AWSLambda-Python-AWS-SDK:1
us-east-2: arn:aws:lambda:us-east-2:259788987135:layer:AWSLambda-Python-AWS-SDK:1
us-west-2: arn:aws:lambda:us-west-2:420165488524:layer:AWSLambda-Python-AWS-SDK:1
cn-north-1: arn:aws-cn:lambda:cn-north-1:683298794825:layer:AWSLambda-Python-AWS-SDK:1
cn-northwest-1: arn:aws-cn:lambda:cn-northwest-1:382066503313:layer:AWSLambda-Python-AWS-SDK:1
us-gov-west-1: arn:aws-us-gov:lambda:us-gov-west-1:556739011827:layer:AWSLambda-Python-AWS-SDK:1
us-gov-east-1: arn:aws-us-gov:lambda:us-gov-east-1:138526772879:layer:AWSLambda-Python-AWS-SDK:1
````

Updating the sam template for the `SendDataCatalogUpdateToElasticSearch` lambda to configure mapping of the layer per region and referring the region specific layer in the lambda function config.

### How are the changes tested?
The changes were tested by setting up data lake in two different regions `ap-southeast-2` and `ap-south-1` and submitting sample payloads through the pipeline. As expected there were no `BotocoreHTTPSession` errors recorded in logs and the events are successfully submitted to elasticsearch.

### Any pending changes?
Unfortunately the python sdk layer for `me-south-1` **Bahrain** region is not available.

cc @tpbrogan @paulmacey1 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
